### PR TITLE
Fix/23  updating existing style wrapper

### DIFF
--- a/src/lib/source/hast/style_wrapper.spec.ts
+++ b/src/lib/source/hast/style_wrapper.spec.ts
@@ -9,9 +9,10 @@ import { removePosition } from 'unist-util-remove-position';
 import { select } from 'hast-util-select';
 import type { HastRoot, HastElement } from 'mdast-util-to-hast/lib/state';
 import type { Node } from 'hast';
-import { trimLeads } from './utils/trim_leads';
-import { buildMarkdownStyleWrapper } from './source/hast/style_wrapper';
-import { removeBlankTextNodes, replaceMarkdownAt } from './source/hast/utils';
+
+import { trimLeads } from '$lib/utils/trim_leads';
+import { buildMarkdownStyleWrapper } from './style_wrapper';
+import { removeBlankTextNodes, replaceMarkdownAt } from './utils';
 
 describe('computeInsertStyle', () => {
   describe.skip('inline', () => {


### PR DESCRIPTION
Add a check block inside buildMarkdownStyleWrapper() and if it is already a wrapper, return with buildInlineStyle() call.

Simple, two lines of code.

This fixes #23