### PR TITLE
Fix/toc sidebar reshown

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,9 +30,7 @@
 
   let editorWidthRatio = 0.5;
   let prevEditorWidthRatio = editorWidthRatio;
-  let _previewWidthRatio: number; // soley depends on editorWidthRatio
-  $: _previewWidthRatio = 1.0 - editorWidthRatio;
-  $: console.log('🚀 _previewWidthRatio:', _previewWidthRatio);
+  $: previewWidthRatio = 1.0 - editorWidthRatio;
 
   // update tocWidth on showToc
   $: {
@@ -54,8 +52,9 @@
     }
   }
 
-  $: editorWidthRatio = updateEditorWidthRatioOnShowEditor(showEditor);
-  $: editorWidthRatio = updateEditorWidthRatioOnShowPreview(showPreview);
+  // update editorWidthRatio on showEditor & showPreview
+  $: ({ editorWidthRatio } = updateEditorWidthRatioOnShowEditor(showEditor));
+  $: ({ editorWidthRatio } = updateEditorWidthRatioOnShowPreview(showPreview));
 
   function updateEditorWidthRatioOnShowEditor(showEditor: boolean) {
     if (showEditor) {
@@ -68,16 +67,7 @@
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 0.0;
     }
-    console.log(
-      '🚀 ~ file: +page.svelte:69 ~ updateEditorWidthRatioOnShowEditor ~ editorWidthRatio:',
-      editorWidthRatio,
-      {
-        showEditor,
-        showPreview,
-        prevEditorWidthRatio,
-      }
-    );
-    return editorWidthRatio;
+    return { editorWidthRatio };
   }
 
   function updateEditorWidthRatioOnShowPreview(showPreview: boolean) {
@@ -91,27 +81,7 @@
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 1.0;
     }
-    console.log(
-      '🚀 ~ file: +page.svelte:92 ~ updateEditorWidthRatioOnShowPreview ~ editorWidthRatio:',
-      editorWidthRatio,
-      {
-        showEditor,
-        showPreview,
-        prevEditorWidthRatio,
-      }
-    );
-    return editorWidthRatio;
-  }
-
-  // update editorWidthRatio on showEditor / showPreview
-  $: {
-    if (showEditor && showPreview) {
-    } else if (showEditor && !showPreview) {
-    } else if (!showEditor && showPreview) {
-    }
-    // never.
-    else {
-    }
+    return { editorWidthRatio };
   }
 
   export const snapshot: Snapshot = {
@@ -124,8 +94,6 @@
       selectedSlideIndex: $selectedNode1Index,
     }),
     restore: (state) => {
-      console.log('🚀 ~ file: +page.svelte:88 ~ state:', state);
-
       $markdown = state.markdown || WELCOME_MESSAGE;
       showToc = state.showToc;
       showEditor = state.showEditor;
@@ -221,7 +189,7 @@
     style:--toc-width={`${tocWidth}px`}
     style:--properties-width={`${propertiesWidth}px`}
     style:--editor-width={`minmax(0, ${editorWidthRatio * 100}fr)`}
-    style:--preview-width={`minmax(0, ${_previewWidthRatio * 100}fr)`}
+    style:--preview-width={`minmax(0, ${previewWidthRatio * 100}fr)`}
   >
     <nav class="navigator">
       <div class="left">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -45,8 +45,8 @@
       selectedSlideIndex: $selectedNode1Index,
     }),
     restore: (state) => {
+      console.log('🚀 ~ restore state:', state);
       $markdown = state.markdown || WELCOME_MESSAGE;
-      console.log('🚀 ~ file: +page.svelte:60 ~ $markdown:', $markdown, { state });
       showToc = state.showToc;
       showEditor = state.showEditor;
       showProperties = state.showProperties;
@@ -79,46 +79,76 @@
   function toggleShowToc() {
     if (showToc) {
       showToc = false;
+    } else {
+      showToc = true;
+    }
+  }
+
+  // update tocWidth on showToc
+  $: {
+    if (!showToc) {
       prevTocWidth = tocWidth;
       tocWidth = 0;
     } else {
-      showToc = true;
       tocWidth = prevTocWidth;
     }
   }
+
   function toggleShowProperties() {
     if (showProperties) {
       showProperties = false;
+    } else {
+      showProperties = true;
+    }
+  }
+
+  // update propertiesWidth on showProperties
+  $: {
+    if (!showProperties) {
       prevPropertiesWidth = propertiesWidth;
       propertiesWidth = 0;
     } else {
-      showProperties = true;
       propertiesWidth = prevPropertiesWidth;
     }
   }
 
   function toggleShowEditor() {
-    console.log('🚀 ~ toggleShowEditor ~ showEditor:', showEditor);
     if (showEditor) {
       showEditor = false;
+    } else {
+      showEditor = true;
+    }
+  }
+
+  // update editorWidthRatio on showEditor
+  $: {
+    if (!showEditor) {
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 0.0;
     } else {
-      showEditor = true;
       editorWidthRatio = prevEditorWidthRatio;
     }
-    console.log('🚀 ~ editorWidthRatio:', editorWidthRatio, { prevEditorWidthRatio });
   }
 
   function toggleShowPreview() {
     // turn showPreview on
     if (!showPreview) {
       showPreview = true;
-      editorWidthRatio = prevEditorWidthRatio;
     }
     // turn off
     else {
       showPreview = false;
+    }
+  }
+
+  // update editorWidthRatio on showPreview
+  $: {
+    // turn showPreview on
+    if (showPreview) {
+      editorWidthRatio = prevEditorWidthRatio;
+    }
+    // turn off
+    else {
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 1.0;
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,13 +27,51 @@
   let propertiesWidth = 200;
   let prevTocWidth = tocWidth;
   let prevPropertiesWidth = propertiesWidth;
-  //$: propertiesWidth = showProperties ? prevTocWidth : 0;
-  //$: tocWidth = showToc ? prevTocWidth : 0;
 
   let editorWidthRatio = 0.5;
   let prevEditorWidthRatio = editorWidthRatio;
   let _previewWidthRatio: number; // soley depends on editorWidthRatio
   $: _previewWidthRatio = 1.0 - editorWidthRatio;
+
+  // update tocWidth on showToc
+  $: {
+    if (!showToc) {
+      prevTocWidth = tocWidth;
+      tocWidth = 0;
+    } else {
+      tocWidth = prevTocWidth;
+    }
+  }
+
+  // update propertiesWidth on showProperties
+  $: {
+    if (!showProperties) {
+      prevPropertiesWidth = propertiesWidth;
+      propertiesWidth = 0;
+    } else {
+      propertiesWidth = prevPropertiesWidth;
+    }
+  }
+
+  // update editorWidthRatio on showEditor
+  $: {
+    if (!showEditor) {
+      prevEditorWidthRatio = editorWidthRatio;
+      editorWidthRatio = 0.0;
+    } else {
+      editorWidthRatio = prevEditorWidthRatio;
+    }
+  }
+
+  // update editorWidthRatio on showPreview
+  $: {
+    if (showPreview) {
+      editorWidthRatio = prevEditorWidthRatio;
+    } else {
+      prevEditorWidthRatio = editorWidthRatio;
+      editorWidthRatio = 1.0;
+    }
+  }
 
   export const snapshot: Snapshot = {
     capture: () => ({
@@ -45,7 +83,6 @@
       selectedSlideIndex: $selectedNode1Index,
     }),
     restore: (state) => {
-      console.log('🚀 ~ restore state:', state);
       $markdown = state.markdown || WELCOME_MESSAGE;
       showToc = state.showToc;
       showEditor = state.showEditor;
@@ -77,81 +114,19 @@
   }
 
   function toggleShowToc() {
-    if (showToc) {
-      showToc = false;
-    } else {
-      showToc = true;
-    }
-  }
-
-  // update tocWidth on showToc
-  $: {
-    if (!showToc) {
-      prevTocWidth = tocWidth;
-      tocWidth = 0;
-    } else {
-      tocWidth = prevTocWidth;
-    }
+    showToc = !showToc;
   }
 
   function toggleShowProperties() {
-    if (showProperties) {
-      showProperties = false;
-    } else {
-      showProperties = true;
-    }
-  }
-
-  // update propertiesWidth on showProperties
-  $: {
-    if (!showProperties) {
-      prevPropertiesWidth = propertiesWidth;
-      propertiesWidth = 0;
-    } else {
-      propertiesWidth = prevPropertiesWidth;
-    }
+    showProperties = !showProperties;
   }
 
   function toggleShowEditor() {
-    if (showEditor) {
-      showEditor = false;
-    } else {
-      showEditor = true;
-    }
-  }
-
-  // update editorWidthRatio on showEditor
-  $: {
-    if (!showEditor) {
-      prevEditorWidthRatio = editorWidthRatio;
-      editorWidthRatio = 0.0;
-    } else {
-      editorWidthRatio = prevEditorWidthRatio;
-    }
+    showEditor = !showEditor;
   }
 
   function toggleShowPreview() {
-    // turn showPreview on
-    if (!showPreview) {
-      showPreview = true;
-    }
-    // turn off
-    else {
-      showPreview = false;
-    }
-  }
-
-  // update editorWidthRatio on showPreview
-  $: {
-    // turn showPreview on
-    if (showPreview) {
-      editorWidthRatio = prevEditorWidthRatio;
-    }
-    // turn off
-    else {
-      prevEditorWidthRatio = editorWidthRatio;
-      editorWidthRatio = 1.0;
-    }
+    showPreview = !showPreview;
   }
 
   async function handleGistPage(pageHash: string): Promise<boolean> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,6 +32,7 @@
   let prevEditorWidthRatio = editorWidthRatio;
   let _previewWidthRatio: number; // soley depends on editorWidthRatio
   $: _previewWidthRatio = 1.0 - editorWidthRatio;
+  $: console.log('🚀 _previewWidthRatio:', _previewWidthRatio);
 
   // update tocWidth on showToc
   $: {
@@ -53,23 +54,63 @@
     }
   }
 
-  // update editorWidthRatio on showEditor
-  $: {
-    if (!showEditor) {
+  $: editorWidthRatio = updateEditorWidthRatioOnShowEditor(showEditor);
+  $: editorWidthRatio = updateEditorWidthRatioOnShowPreview(showPreview);
+
+  function updateEditorWidthRatioOnShowEditor(showEditor: boolean) {
+    if (showEditor) {
+      if (showPreview) {
+        editorWidthRatio = prevEditorWidthRatio;
+      } else {
+        editorWidthRatio = 1.0;
+      }
+    } else {
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 0.0;
-    } else {
-      editorWidthRatio = prevEditorWidthRatio;
     }
+    console.log(
+      '🚀 ~ file: +page.svelte:69 ~ updateEditorWidthRatioOnShowEditor ~ editorWidthRatio:',
+      editorWidthRatio,
+      {
+        showEditor,
+        showPreview,
+        prevEditorWidthRatio,
+      }
+    );
+    return editorWidthRatio;
   }
 
-  // update editorWidthRatio on showPreview
-  $: {
+  function updateEditorWidthRatioOnShowPreview(showPreview: boolean) {
     if (showPreview) {
-      editorWidthRatio = prevEditorWidthRatio;
+      if (showEditor) {
+        editorWidthRatio = prevEditorWidthRatio;
+      } else {
+        editorWidthRatio = 0.0;
+      }
     } else {
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 1.0;
+    }
+    console.log(
+      '🚀 ~ file: +page.svelte:92 ~ updateEditorWidthRatioOnShowPreview ~ editorWidthRatio:',
+      editorWidthRatio,
+      {
+        showEditor,
+        showPreview,
+        prevEditorWidthRatio,
+      }
+    );
+    return editorWidthRatio;
+  }
+
+  // update editorWidthRatio on showEditor / showPreview
+  $: {
+    if (showEditor && showPreview) {
+    } else if (showEditor && !showPreview) {
+    } else if (!showEditor && showPreview) {
+    }
+    // never.
+    else {
     }
   }
 
@@ -83,6 +124,8 @@
       selectedSlideIndex: $selectedNode1Index,
     }),
     restore: (state) => {
+      console.log('🚀 ~ file: +page.svelte:88 ~ state:', state);
+
       $markdown = state.markdown || WELCOME_MESSAGE;
       showToc = state.showToc;
       showEditor = state.showEditor;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,33 +53,22 @@
   }
 
   // update editorWidthRatio on showEditor & showPreview
-  $: ({ editorWidthRatio } = updateEditorWidthRatioOnShowEditor(showEditor));
-  $: ({ editorWidthRatio } = updateEditorWidthRatioOnShowPreview(showPreview));
+  $: ({ editorWidthRatio } = updateEditorWidthRatio(showEditor, showPreview));
 
-  function updateEditorWidthRatioOnShowEditor(showEditor: boolean) {
-    if (showEditor) {
-      if (showPreview) {
-        editorWidthRatio = prevEditorWidthRatio;
-      } else {
-        editorWidthRatio = 1.0;
-      }
-    } else {
+  function updateEditorWidthRatio(showEditor: boolean, showPreview: boolean) {
+    if (showPreview && showEditor) {
+      editorWidthRatio = prevEditorWidthRatio;
+    } else if (showPreview && !showEditor) {
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 0.0;
-    }
-    return { editorWidthRatio };
-  }
-
-  function updateEditorWidthRatioOnShowPreview(showPreview: boolean) {
-    if (showPreview) {
-      if (showEditor) {
-        editorWidthRatio = prevEditorWidthRatio;
-      } else {
-        editorWidthRatio = 0.0;
-      }
-    } else {
+    } else if (!showPreview && showEditor) {
       prevEditorWidthRatio = editorWidthRatio;
       editorWidthRatio = 1.0;
+    }
+    // never
+    else {
+      console.error('showPreviw and showEditor cannot be both false. returning to initial state.');
+      editorWidthRatio = 0.5;
     }
     return { editorWidthRatio };
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -182,10 +182,14 @@
   >
     <nav class="navigator">
       <div class="left">
-        <button on:click={toggleShowToc}>ToC</button>
-        <button on:click={toggleShowEditor}>Editor</button>
-        <button on:click={toggleShowPreview}>Preview</button>
-        <button on:click={toggleShowProperties}>Properties</button>
+        <button aria-pressed={showToc} on:click={toggleShowToc}>ToC</button>
+        <button aria-pressed={showEditor} on:click={toggleShowEditor} disabled={!showPreview}
+          >Editor</button
+        >
+        <button aria-pressed={showPreview} on:click={toggleShowPreview} disabled={!showEditor}
+          >Preview</button
+        >
+        <button aria-pressed={showProperties} on:click={toggleShowProperties}>Properties</button>
       </div>
       <div class="right">
         <button on:click={() => (showPresentation = true)}>Presentation</button>
@@ -301,10 +305,22 @@
   .navigator > div {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 6px;
   }
   .navigator button {
     height: 24px;
+    position: relative;
+    box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
+  }
+  .navigator button[aria-pressed='true'] {
+    top: 1px;
+    left: 1px;
+    box-shadow: none;
+  }
+  .navigator button:disabled {
+    background-color: rgba(239, 239, 239, 0.7);
+    color: rgba(16, 16, 16, 0.7);
+    border-color: rgba(118, 118, 118, 0.1);
   }
 
   .toc {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -113,22 +113,6 @@
     $selecteds = $selecteds;
   }
 
-  function toggleShowToc() {
-    showToc = !showToc;
-  }
-
-  function toggleShowProperties() {
-    showProperties = !showProperties;
-  }
-
-  function toggleShowEditor() {
-    showEditor = !showEditor;
-  }
-
-  function toggleShowPreview() {
-    showPreview = !showPreview;
-  }
-
   async function handleGistPage(pageHash: string): Promise<boolean> {
     let gistContent = await getGistContent(pageHash);
     if (!gistContent) {
@@ -182,14 +166,20 @@
   >
     <nav class="navigator">
       <div class="left">
-        <button aria-pressed={showToc} on:click={toggleShowToc}>ToC</button>
-        <button aria-pressed={showEditor} on:click={toggleShowEditor} disabled={!showPreview}
-          >Editor</button
+        <button aria-pressed={showToc} on:click={() => (showToc = !showToc)}>ToC</button>
+        <button
+          aria-pressed={showEditor}
+          disabled={!showPreview}
+          on:click={() => (showEditor = !showEditor)}>Editor</button
         >
-        <button aria-pressed={showPreview} on:click={toggleShowPreview} disabled={!showEditor}
-          >Preview</button
+        <button
+          aria-pressed={showPreview}
+          disabled={!showEditor}
+          on:click={() => (showPreview = !showPreview)}>Preview</button
         >
-        <button aria-pressed={showProperties} on:click={toggleShowProperties}>Properties</button>
+        <button aria-pressed={showProperties} on:click={() => (showProperties = !showProperties)}
+          >Properties</button
+        >
       </div>
       <div class="right">
         <button on:click={() => (showPresentation = true)}>Presentation</button>


### PR DESCRIPTION
Problem: `showToc` can be updated via `restoreSessionStorageSnapshot()`,
but current implementation only updated `tocWidth` on `toggleShowToc()`.

States that depends on other states would be better to live on reactive statements.

FIX: move updating `tocWidth` and `prevTocWidth` to reactive statement blocks.
(applied for other states too)

This fixes #24